### PR TITLE
Add an it_it language file

### DIFF
--- a/src/main/resources/assets/spruceui/lang/it_it.json
+++ b/src/main/resources/assets/spruceui/lang/it_it.json
@@ -1,4 +1,12 @@
 {
   "spruceui.reset": "Ripristina",
-  "spruceui.options.generic": "%s: %s"
+  "spruceui.narrator.separator": "Separatore %s",
+  "spruceui.options.generic": "%s: %s",
+  "spruceui.not_bound": "Non associato",
+  "spruceui.options.generic.fancy": "Sofisticato",
+  "spruceui.options.generic.fast": "Semplice",
+  "spruceui.options.generic.fastest": "Semplicissimo",
+  "spruceui.options.generic.simple": "Semplice",
+  "spruceui.options.generic.unbound": "Disassocia",
+  "spruceui.widget.separator": "Separatore"
 }


### PR DESCRIPTION
There are two "Semplice" in order to stay consistent with the official translation of the game.
"Unbound" as noted by @LambdAurora is actually a typo, and refers to the action of unbinding.