### PR TITLE
New ModMenu API for library badge

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -35,6 +35,8 @@
     "ltr": "*"
   },
   "custom": {
-    "modmenu:api": true
+    "modmenu": {
+      "badges": ["library"]
+    }
   }
 }


### PR DESCRIPTION
This pr changes the fabric.mod.json to use the new modmenu api for the library badge that will remove the log error about it being depreciated. This change has already been done to the 1.17 branch but this fixes it for all future versions of the mod that are for 1.16.