### PR TITLE
Add ability for SpruceEntryListWidget children to override scroll behaviour

### DIFF
--- a/src/main/java/dev/lambdaurora/spruceui/widget/container/SpruceEntryListWidget.java
+++ b/src/main/java/dev/lambdaurora/spruceui/widget/container/SpruceEntryListWidget.java
@@ -311,6 +311,7 @@ public abstract class SpruceEntryListWidget<E extends SpruceEntryListWidget.Entr
 
     @Override
     protected boolean onMouseScroll(double mouseX, double mouseY, double amount) {
+        if(super.onMouseScroll(mouseX, mouseY, amount)) return true;
         this.setScrollAmount(this.getScrollAmount() - amount * ((double) this.getMaxPosition() / this.getEntriesCount()) / 2);
         return true;
     }


### PR DESCRIPTION
Necessary to completely fix https://github.com/LambdAurora/LambdaMap/issues/2 as the current behaviour results in not notifying SpruceEntryListWidget children of scroll events.