### PR TITLE
Fix dragging status being incorrect after container focus switch

### DIFF
--- a/src/main/java/dev/lambdaurora/spruceui/widget/AbstractSpruceWidget.java
+++ b/src/main/java/dev/lambdaurora/spruceui/widget/AbstractSpruceWidget.java
@@ -101,7 +101,9 @@ public abstract class AbstractSpruceWidget implements SpruceWidget {
 	@Override
 	public void setFocused(boolean focused) {
 		this.focused = focused;
-		this.dragging = false;
+		if (!focused) {
+			this.dragging = false;
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Fixes a minor issue with dragging, primarily affecting slider widgets, as discussed in Discord.