### PR TITLE
Port to 26.1-pre-1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 import dev.lambdaurora.mcdev.api.McVersionLookup
-import dev.lambdaurora.mcdev.task.ConvertAccessWidenerToTransformer
 
 plugins {
 	alias(libs.plugins.loom)
@@ -59,7 +58,6 @@ lambdamcdev {
 			withDepend("fabric-resource-loader-v1", ">=2.0.5")
 			withDepend("java", ">=${project.property("java_version")}")
 			withDepend("yumi_mc_core", "^${libs.versions.yumi.mc.foundation.get()}")
-			withAccessWidener("spruceui.accesswidener")
 			withMixins("spruceui.mixins.json")
 
 			withModMenu {
@@ -82,7 +80,6 @@ lambdamcdev {
 }
 
 loom {
-	accessWidenerPath = file("src/main/resources/spruceui.accesswidener")
 	mixin {
 		useLegacyMixinAp = false
 	}
@@ -140,20 +137,11 @@ tasks.withType<JavaCompile>().configureEach {
 	options.isIncremental = true
 }
 
-val convertAWtoAT by tasks.registering(ConvertAccessWidenerToTransformer::class) {
-	this.group = "generation"
-	this.input = loom.accessWidenerPath
-	this.output = project.layout.buildDirectory.get().file("generated/accesstransformer.cfg")
-}
-
 tasks.jar {
 	inputs.property("archivesName", base.archivesName)
 
 	from("LICENSE") {
 		rename { "${it}_${inputs.properties["archivesName"]}" }
-	}
-	from(convertAWtoAT) {
-		into("META-INF")
 	}
 }
 
@@ -162,9 +150,6 @@ tasks.named<Jar>("sourcesJar") {
 
 	from("LICENSE") {
 		rename { "${it}_${inputs.properties["archivesName"]}" }
-	}
-	from(convertAWtoAT) {
-		into("META-INF")
 	}
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -106,7 +106,7 @@ repositories {
 	}
 	maven {
 		name = "NeoForge"
-		url = uri("https://maven.neoforged.net/")
+		url = uri("https://maven.neoforged.net/releases/")
 		content {
 			includeGroupByRegex("net\\.neoforged.*")
 			includeGroupByRegex("cpw\\.mods.*")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
-minecraft = "26.1-snapshot-6"
+minecraft = "26.1-pre-1"
 fabric-loader = "0.18.4"
 neoforge-loader = "10.0.10"
-fabric-api = "0.143.2+26.1"
-modmenu = "15.0.0-beta.1"
+fabric-api = "0.143.12+26.1"
+modmenu = "18.0.0-alpha.5"
 
 yumi-mc-foundation = "1.0.0-beta.2+26.1-snapshot-6"
 

--- a/src/main/java/dev/lambdaurora/spruceui/background/Background.java
+++ b/src/main/java/dev/lambdaurora/spruceui/background/Background.java
@@ -20,5 +20,5 @@ import dev.lambdaurora.spruceui.widget.SpruceWidget;
  * @since 2.0.0
  */
 public interface Background {
-	void render(SpruceGuiGraphics graphics, SpruceWidget widget, int vOffset, int mouseX, int mouseY, float delta);
+	void extractRenderState(SpruceGuiGraphics graphics, SpruceWidget widget, int vOffset, int mouseX, int mouseY, float delta);
 }

--- a/src/main/java/dev/lambdaurora/spruceui/background/DirtTexturedBackground.java
+++ b/src/main/java/dev/lambdaurora/spruceui/background/DirtTexturedBackground.java
@@ -18,8 +18,8 @@ public record DirtTexturedBackground(int red, int green, int blue, int alpha) im
 	public static final Background DARKENED = new DirtTexturedBackground(32, 32, 32, 255);
 
 	@Override
-	public void render(SpruceGuiGraphics graphics, SpruceWidget widget, int vOffset, int mouseX, int mouseY, float delta) {
-		RenderUtil.renderBackgroundTexture(graphics,
+	public void extractRenderState(SpruceGuiGraphics graphics, SpruceWidget widget, int vOffset, int mouseX, int mouseY, float delta) {
+		RenderUtil.extractBackgroundTexture(graphics,
 				widget.getX(), widget.getY(), widget.getWidth(), widget.getHeight(),
 				vOffset / 32.f, this.red, this.green, this.blue, this.alpha
 		);

--- a/src/main/java/dev/lambdaurora/spruceui/background/EmptyBackground.java
+++ b/src/main/java/dev/lambdaurora/spruceui/background/EmptyBackground.java
@@ -26,7 +26,7 @@ public final class EmptyBackground implements Background {
 	}
 
 	@Override
-	public void render(SpruceGuiGraphics graphics, SpruceWidget widget, int vOffset, int mouseX, int mouseY, float delta) {
+	public void extractRenderState(SpruceGuiGraphics graphics, SpruceWidget widget, int vOffset, int mouseX, int mouseY, float delta) {
 	}
 
 	@Override

--- a/src/main/java/dev/lambdaurora/spruceui/background/MenuBackground.java
+++ b/src/main/java/dev/lambdaurora/spruceui/background/MenuBackground.java
@@ -35,7 +35,7 @@ public record MenuBackground(Identifier texture, Identifier inWorldTexture) impl
 	);
 
 	@Override
-	public void render(SpruceGuiGraphics graphics, SpruceWidget widget, int vOffset, int mouseX, int mouseY, float delta) {
+	public void extractRenderState(SpruceGuiGraphics graphics, SpruceWidget widget, int vOffset, int mouseX, int mouseY, float delta) {
 		int x = widget.getX();
 		int y = widget.getY();
 		int width = widget.getWidth();
@@ -52,7 +52,7 @@ public record MenuBackground(Identifier texture, Identifier inWorldTexture) impl
 		}
 
 		Identifier identifier = CLIENT.level == null ? this.inWorldTexture : this.texture;
-		graphics.drawTexture(
+		graphics.blit(
 				RenderPipelines.GUI_TEXTURED, identifier,
 				x, y,
 				0, 0,

--- a/src/main/java/dev/lambdaurora/spruceui/background/SimpleColorBackground.java
+++ b/src/main/java/dev/lambdaurora/spruceui/background/SimpleColorBackground.java
@@ -25,7 +25,7 @@ public class SimpleColorBackground implements Background {
 	}
 
 	@Override
-	public void render(SpruceGuiGraphics graphics, SpruceWidget widget, int vOffset, int mouseX, int mouseY, float delta) {
+	public void extractRenderState(SpruceGuiGraphics graphics, SpruceWidget widget, int vOffset, int mouseX, int mouseY, float delta) {
 		int x = widget.getX();
 		int y = widget.getY();
 		graphics.fill(x, y, x + widget.getWidth(), y + widget.getHeight(), this.color);

--- a/src/main/java/dev/lambdaurora/spruceui/border/Border.java
+++ b/src/main/java/dev/lambdaurora/spruceui/border/Border.java
@@ -20,7 +20,7 @@ import dev.lambdaurora.spruceui.widget.SpruceWidget;
  * @since 2.0.0
  */
 public interface Border {
-	void render(SpruceGuiGraphics graphics, SpruceWidget widget, int mouseX, int mouseY, float delta);
+	void extractRenderState(SpruceGuiGraphics graphics, SpruceWidget widget, int mouseX, int mouseY, float delta);
 
 	/**
 	 * Returns the thickness of the top border.

--- a/src/main/java/dev/lambdaurora/spruceui/border/EmptyBorder.java
+++ b/src/main/java/dev/lambdaurora/spruceui/border/EmptyBorder.java
@@ -26,7 +26,7 @@ public final class EmptyBorder implements Border {
 	}
 
 	@Override
-	public void render(SpruceGuiGraphics graphics, SpruceWidget widget, int mouseX, int mouseY, float delta) {
+	public void extractRenderState(SpruceGuiGraphics graphics, SpruceWidget widget, int mouseX, int mouseY, float delta) {
 	}
 
 	@Override

--- a/src/main/java/dev/lambdaurora/spruceui/border/MenuBorder.java
+++ b/src/main/java/dev/lambdaurora/spruceui/border/MenuBorder.java
@@ -35,7 +35,7 @@ public record MenuBorder(boolean top, boolean right, boolean bottom, boolean lef
 	public static final MenuBorder TAB_LIST = new MenuBorder(true, true, true, false);
 
 	@Override
-	public void render(SpruceGuiGraphics graphics, SpruceWidget widget, int mouseX, int mouseY, float delta) {
+	public void extractRenderState(SpruceGuiGraphics graphics, SpruceWidget widget, int mouseX, int mouseY, float delta) {
 		if (this.top) {
 			Identifier topTexture = CLIENT.level == null
 					? SpruceTextures.MENU_TOP_BORDER
@@ -47,7 +47,7 @@ public record MenuBorder(boolean top, boolean right, boolean bottom, boolean lef
 				width -= THICKNESS;
 			}
 
-			graphics.drawTexture(
+			graphics.blit(
 					RenderPipelines.GUI_TEXTURED,
 					topTexture,
 					widget.getX(), widget.getY(),
@@ -61,7 +61,7 @@ public record MenuBorder(boolean top, boolean right, boolean bottom, boolean lef
 			Identifier cornerTexture = CLIENT.level == null
 					? SpruceTextures.MENU_TOP_RIGHT_BORDER
 					: SpruceTextures.INWORLD_MENU_TOP_RIGHT_BORDER;
-			graphics.drawTexture(
+			graphics.blit(
 					RenderPipelines.GUI_TEXTURED,
 					cornerTexture,
 					widget.getEndX() - THICKNESS, widget.getY(),
@@ -88,7 +88,7 @@ public record MenuBorder(boolean top, boolean right, boolean bottom, boolean lef
 				height -= THICKNESS;
 			}
 
-			graphics.drawTexture(
+			graphics.blit(
 					RenderPipelines.GUI_TEXTURED, rightTexture,
 					widget.getEndX() - THICKNESS, y,
 					0, 0,
@@ -100,7 +100,7 @@ public record MenuBorder(boolean top, boolean right, boolean bottom, boolean lef
 		if (this.bottom && this.right) {
 			Identifier cornerTexture = CLIENT.level == null
 					? SpruceTextures.MENU_BOTTOM_RIGHT_BORDER : SpruceTextures.INWORLD_MENU_BOTTOM_RIGHT_BORDER;
-			graphics.drawTexture(
+			graphics.blit(
 					RenderPipelines.GUI_TEXTURED,
 					cornerTexture,
 					widget.getEndX() - THICKNESS, widget.getEndY() - THICKNESS,
@@ -121,7 +121,7 @@ public record MenuBorder(boolean top, boolean right, boolean bottom, boolean lef
 				width -= THICKNESS;
 			}
 
-			graphics.drawTexture(
+			graphics.blit(
 					RenderPipelines.GUI_TEXTURED,
 					bottomTexture,
 					widget.getX(), widget.getEndY() - THICKNESS,

--- a/src/main/java/dev/lambdaurora/spruceui/border/SimpleBorder.java
+++ b/src/main/java/dev/lambdaurora/spruceui/border/SimpleBorder.java
@@ -48,7 +48,7 @@ public final class SimpleBorder implements Border {
 	}
 
 	@Override
-	public void render(SpruceGuiGraphics graphics, SpruceWidget widget, int mouseX, int mouseY, float delta) {
+	public void extractRenderState(SpruceGuiGraphics graphics, SpruceWidget widget, int mouseX, int mouseY, float delta) {
 		int x = widget.getX();
 		int y = widget.getY();
 		int right = x + widget.getWidth();

--- a/src/main/java/dev/lambdaurora/spruceui/border/TexturedBorder.java
+++ b/src/main/java/dev/lambdaurora/spruceui/border/TexturedBorder.java
@@ -29,8 +29,8 @@ public record TexturedBorder(WidgetSprites sprites) implements Border {
 	));
 
 	@Override
-	public void render(SpruceGuiGraphics graphics, SpruceWidget widget, int mouseX, int mouseY, float delta) {
-		graphics.drawSprite(
+	public void extractRenderState(SpruceGuiGraphics graphics, SpruceWidget widget, int mouseX, int mouseY, float delta) {
+		graphics.blitSprite(
 				RenderPipelines.GUI_TEXTURED, this.sprites.get(widget.isActive(), widget.isFocusedOrHovered()),
 				widget.getX(), widget.getY(),
 				widget.getWidth(), widget.getHeight()

--- a/src/main/java/dev/lambdaurora/spruceui/impl/GuiGraphicsAccessor.java
+++ b/src/main/java/dev/lambdaurora/spruceui/impl/GuiGraphicsAccessor.java
@@ -10,15 +10,15 @@
 package dev.lambdaurora.spruceui.impl;
 
 import dev.lambdaurora.spruceui.render.SpruceGuiGraphics;
-import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.render.state.GuiRenderState;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.renderer.state.gui.GuiRenderState;
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
 public interface GuiGraphicsAccessor {
 	SpruceGuiGraphics spruceui$spruced();
 
-	GuiGraphics.ScissorStack spruceui$getScissorStack();
+	GuiGraphicsExtractor.ScissorStack spruceui$getScissorStack();
 
 	GuiRenderState spruceui$getGuiRenderState();
 }

--- a/src/main/java/dev/lambdaurora/spruceui/mixin/GameRendererMixin.java
+++ b/src/main/java/dev/lambdaurora/spruceui/mixin/GameRendererMixin.java
@@ -13,7 +13,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import dev.lambdaurora.spruceui.event.ScreenEvents;
 import dev.lambdaurora.spruceui.render.SpruceGuiGraphics;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.renderer.GameRenderer;
 import org.spongepowered.asm.mixin.Dynamic;
@@ -25,23 +25,26 @@ public class GameRendererMixin {
 	@SuppressWarnings({"MixinAnnotationTarget"})
 	@Dynamic
 	@WrapOperation(
-			method = "render",
+			method = "extractGui",
 			at = {
 					@At(
 							value = "INVOKE",
-							target = "Lnet/minecraft/client/gui/screens/Screen;renderWithTooltipAndSubtitles(Lnet/minecraft/client/gui/GuiGraphics;IIF)V"
+							target = "Lnet/minecraft/client/gui/screens/Screen;extractRenderStateWithTooltipAndSubtitles(Lnet/minecraft/client/gui/GuiGraphicsExtractor;IIF)V"
 					),
+					// FIXME: see what Neoforge names this hook.
+					/*
 					@At(
 							value = "INVOKE",
-							target = "Lnet/neoforged/neoforge/client/ClientHooks;drawScreen(Lnet/minecraft/client/gui/screens/Screen;Lnet/minecraft/client/gui/GuiGraphics;IIF)V",
+							target = "Lnet/neoforged/neoforge/client/ClientHooks;drawScreen(Lnet/minecraft/client/gui/screens/Screen;Lnet/minecraft/client/gui/GuiGraphicsExtractor;IIF)V",
 							remap = false
 					),
+					*/
 			},
 			require = 1,
 			allow = 1
 	)
 	private void spruceui$onRenderScreen(
-			Screen currentScreen, GuiGraphics graphics, int mouseX, int mouseY, float tickDelta, Operation<Void> operation
+			Screen currentScreen, GuiGraphicsExtractor graphics, int mouseX, int mouseY, float tickDelta, Operation<Void> operation
 	) {
 		var sprucedGraphics = SpruceGuiGraphics.of(graphics);
 

--- a/src/main/java/dev/lambdaurora/spruceui/mixin/GuiGraphicsExtractorMixin.java
+++ b/src/main/java/dev/lambdaurora/spruceui/mixin/GuiGraphicsExtractorMixin.java
@@ -22,7 +22,7 @@ import org.spongepowered.asm.mixin.Unique;
 
 @Environment(EnvType.CLIENT)
 @Mixin(GuiGraphicsExtractor.class)
-public class GuiGraphicsMixin implements GuiGraphicsAccessor {
+public class GuiGraphicsExtractorMixin implements GuiGraphicsAccessor {
 	@Unique
 	private final SpruceGuiGraphics spruce$graphics = new SpruceGuiGraphics((GuiGraphicsExtractor) (Object) this);
 

--- a/src/main/java/dev/lambdaurora/spruceui/mixin/GuiGraphicsMixin.java
+++ b/src/main/java/dev/lambdaurora/spruceui/mixin/GuiGraphicsMixin.java
@@ -13,22 +13,22 @@ import dev.lambdaurora.spruceui.impl.GuiGraphicsAccessor;
 import dev.lambdaurora.spruceui.render.SpruceGuiGraphics;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.render.state.GuiRenderState;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.renderer.state.gui.GuiRenderState;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 
 @Environment(EnvType.CLIENT)
-@Mixin(GuiGraphics.class)
+@Mixin(GuiGraphicsExtractor.class)
 public class GuiGraphicsMixin implements GuiGraphicsAccessor {
 	@Unique
-	private final SpruceGuiGraphics spruce$graphics = new SpruceGuiGraphics((GuiGraphics) (Object) this);
+	private final SpruceGuiGraphics spruce$graphics = new SpruceGuiGraphics((GuiGraphicsExtractor) (Object) this);
 
 	@Shadow
 	@Final
-	public GuiGraphics.ScissorStack scissorStack;
+	public GuiGraphicsExtractor.ScissorStack scissorStack;
 	@Shadow
 	@Final
 	public GuiRenderState guiRenderState;
@@ -39,7 +39,7 @@ public class GuiGraphicsMixin implements GuiGraphicsAccessor {
 	}
 
 	@Override
-	public GuiGraphics.ScissorStack spruceui$getScissorStack() {
+	public GuiGraphicsExtractor.ScissorStack spruceui$getScissorStack() {
 		return this.scissorStack;
 	}
 

--- a/src/main/java/dev/lambdaurora/spruceui/mixin/MinecraftClientMixin.java
+++ b/src/main/java/dev/lambdaurora/spruceui/mixin/MinecraftClientMixin.java
@@ -41,7 +41,7 @@ public class MinecraftClientMixin {
 	@Unique
 	private Screen tickingScreen;
 
-	@Inject(method = "resizeDisplay", at = @At("RETURN"))
+	@Inject(method = "resizeGui", at = @At("RETURN"))
 	private void onResolutionChanged(CallbackInfo ci) {
 		ResolutionChangeCallback.EVENT.invoker().apply((Minecraft) (Object) this);
 	}

--- a/src/main/java/dev/lambdaurora/spruceui/render/SpruceGuiGraphics.java
+++ b/src/main/java/dev/lambdaurora/spruceui/render/SpruceGuiGraphics.java
@@ -190,7 +190,7 @@ public final class SpruceGuiGraphics {
 			RenderPipeline pipeline, TextureSetup textureSetup, int startX, int startY, int endX, int endY,
 			int colorTopLeft, @Nullable Integer colorTopRight, @Nullable Integer colorBottomRight, @Nullable Integer colorBottomLeft
 	) {
-		this.submitGuiElement(
+		this.addGuiElement(
 				new ColoredRectangleRenderState(
 						pipeline, textureSetup, new Matrix3x2f(this.pose()),
 						startX, startY, endX, endY,
@@ -202,68 +202,68 @@ public final class SpruceGuiGraphics {
 		);
 	}
 
-	public void drawSprite(
+	public void blitSprite(
 			RenderPipeline pipeline, Identifier sprite, int x, int y, int width, int height
 	) {
 		this.wrapped.blitSprite(pipeline, sprite, x, y, width, height);
 	}
 
-	public void drawSprite(
+	public void blitSprite(
 			RenderPipeline pipeline, Identifier sprite, int x, int y, int width, int height, int color
 	) {
 		this.wrapped.blitSprite(pipeline, sprite, x, y, width, height, color);
 	}
 
-	public void drawTexture(
+	public void blit(
 			RenderPipeline renderPipeline, Identifier texture,
 			int x, int y, float u, float v, int width, int height, int textureWidth, int textureHeight
 	) {
 		this.wrapped.blit(renderPipeline, texture, x, y, u, v, width, height, width, height, textureWidth, textureHeight);
 	}
 
-	public void drawText(
+	public void text(
 			Font font, String text, int x, int y, int color, boolean shadow
 	) {
 		this.wrapped.text(font, text, x, y, color, shadow);
 	}
 
-	public void drawText(
+	public void text(
 			Font font, FormattedCharSequence text, int x, int y, int color, boolean shadow
 	) {
 		this.wrapped.text(font, text, x, y, color, shadow);
 	}
 
-	public void drawText(
+	public void text(
 			Font font, Component text, int x, int y, int color, boolean shadow
 	) {
 		this.wrapped.text(font, text, x, y, color, shadow);
 	}
 
-	public void drawShadowedText(
+	public void shadowedText(
 			Font font, String text, int x, int y, int color
 	) {
-		this.drawText(font, text, x, y, color, true);
+		this.text(font, text, x, y, color, true);
 	}
 
-	public void drawShadowedText(
+	public void shadowedText(
 			Font font, FormattedCharSequence text, int x, int y, int color
 	) {
-		this.drawText(font, text, x, y, color, true);
+		this.text(font, text, x, y, color, true);
 	}
 
-	public void drawShadowedText(
+	public void shadowedText(
 			Font font, Component text, int x, int y, int color
 	) {
-		this.drawText(font, text, x, y, color, true);
+		this.text(font, text, x, y, color, true);
 	}
 
-	public void drawCenteredShadowedText(
+	public void centeredShadowedText(
 			Font font, FormattedCharSequence text, int centerX, int y, int color
 	) {
 		this.wrapped.centeredText(font, text, centerX, y, color);
 	}
 
-	public void drawCenteredShadowedText(
+	public void centeredShadowedText(
 			Font font, Component text, int centerX, int y, int color
 	) {
 		this.wrapped.centeredText(font, text, centerX, y, color);
@@ -279,7 +279,7 @@ public final class SpruceGuiGraphics {
 		return new ActiveTextCollector.Parameters(new Matrix3x2f(this.wrapped.pose()), alpha, this.accessor().spruceui$getScissorStack().peek());
 	}
 
-	public void submitGuiElement(GuiElementRenderState state) {
+	public void addGuiElement(GuiElementRenderState state) {
 		this.accessor().spruceui$getGuiRenderState().addGuiElement(state);
 	}
 

--- a/src/main/java/dev/lambdaurora/spruceui/render/SpruceGuiGraphics.java
+++ b/src/main/java/dev/lambdaurora/spruceui/render/SpruceGuiGraphics.java
@@ -15,10 +15,10 @@ import dev.lambdaurora.spruceui.impl.GuiGraphicsAccessor;
 import dev.lambdaurora.spruceui.render.state.ColoredRectangleRenderState;
 import net.minecraft.client.gui.ActiveTextCollector;
 import net.minecraft.client.gui.Font;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.render.TextureSetup;
-import net.minecraft.client.gui.render.state.GuiElementRenderState;
 import net.minecraft.client.renderer.RenderPipelines;
+import net.minecraft.client.renderer.state.gui.GuiElementRenderState;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.FormattedCharSequence;
@@ -27,27 +27,27 @@ import org.joml.Matrix3x2fStack;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Represents a wrapper around {@link GuiGraphics} with extra features.
+ * Represents a wrapper around {@link GuiGraphicsExtractor} with extra features.
  *
  * @author LambdAurora
  * @version 8.0.0
  * @since 8.0.0
  */
 public final class SpruceGuiGraphics {
-	private final GuiGraphics wrapped;
+	private final GuiGraphicsExtractor wrapped;
 
-	public SpruceGuiGraphics(GuiGraphics graphics) {
+	public SpruceGuiGraphics(GuiGraphicsExtractor graphics) {
 		this.wrapped = graphics;
 	}
 
-	public static SpruceGuiGraphics of(GuiGraphics graphics) {
+	public static SpruceGuiGraphics of(GuiGraphicsExtractor graphics) {
 		return ((GuiGraphicsAccessor) graphics).spruceui$spruced();
 	}
 
 	/**
 	 * {@return the wrapped vanilla GUI graphics object}
 	 */
-	public GuiGraphics vanilla() {
+	public GuiGraphicsExtractor vanilla() {
 		return this.wrapped;
 	}
 
@@ -76,7 +76,7 @@ public final class SpruceGuiGraphics {
 	 * @param endY the end Y-coordinate of the scissor area
 	 * @see #disableScissor()
 	 * @see #containsPointInScissor(int, int)
-	 * @see GuiGraphics#enableScissor(int, int, int, int)
+	 * @see GuiGraphicsExtractor#enableScissor(int, int, int, int)
 	 */
 	public void enableScissor(int startX, int startY, int endX, int endY) {
 		this.wrapped.enableScissor(startX, startY, endX, endY);
@@ -87,7 +87,7 @@ public final class SpruceGuiGraphics {
 	 *
 	 * @see #enableScissor(int, int, int, int)
 	 * @see #containsPointInScissor(int, int)
-	 * @see GuiGraphics#disableScissor()
+	 * @see GuiGraphicsExtractor#disableScissor()
 	 */
 	public void disableScissor() {
 		this.wrapped.disableScissor();
@@ -100,7 +100,7 @@ public final class SpruceGuiGraphics {
 	 * @param y the Y-coordinate to check
 	 * @see #enableScissor(int, int, int, int)
 	 * @see #disableScissor()
-	 * @see GuiGraphics#containsPointInScissor(int, int)
+	 * @see GuiGraphicsExtractor#containsPointInScissor(int, int)
 	 */
 	public boolean containsPointInScissor(int x, int y) {
 		return this.wrapped.containsPointInScissor(x, y);
@@ -224,19 +224,19 @@ public final class SpruceGuiGraphics {
 	public void drawText(
 			Font font, String text, int x, int y, int color, boolean shadow
 	) {
-		this.wrapped.drawString(font, text, x, y, color, shadow);
+		this.wrapped.text(font, text, x, y, color, shadow);
 	}
 
 	public void drawText(
 			Font font, FormattedCharSequence text, int x, int y, int color, boolean shadow
 	) {
-		this.wrapped.drawString(font, text, x, y, color, shadow);
+		this.wrapped.text(font, text, x, y, color, shadow);
 	}
 
 	public void drawText(
 			Font font, Component text, int x, int y, int color, boolean shadow
 	) {
-		this.wrapped.drawString(font, text, x, y, color, shadow);
+		this.wrapped.text(font, text, x, y, color, shadow);
 	}
 
 	public void drawShadowedText(
@@ -260,16 +260,16 @@ public final class SpruceGuiGraphics {
 	public void drawCenteredShadowedText(
 			Font font, FormattedCharSequence text, int centerX, int y, int color
 	) {
-		this.wrapped.drawCenteredString(font, text, centerX, y, color);
+		this.wrapped.centeredText(font, text, centerX, y, color);
 	}
 
 	public void drawCenteredShadowedText(
 			Font font, Component text, int centerX, int y, int color
 	) {
-		this.wrapped.drawCenteredString(font, text, centerX, y, color);
+		this.wrapped.centeredText(font, text, centerX, y, color);
 	}
 
-	public ActiveTextCollector textRenderer(float alpha, GuiGraphics.HoveredTextEffects hoveredTextEffects) {
+	public ActiveTextCollector textRenderer(float alpha, GuiGraphicsExtractor.HoveredTextEffects hoveredTextEffects) {
 		var collector = this.wrapped.textRenderer(hoveredTextEffects);
 		collector.defaultParameters(this.createDefaultTextParameters(alpha));
 		return collector;
@@ -280,7 +280,7 @@ public final class SpruceGuiGraphics {
 	}
 
 	public void submitGuiElement(GuiElementRenderState state) {
-		this.accessor().spruceui$getGuiRenderState().submitGuiElement(state);
+		this.accessor().spruceui$getGuiRenderState().addGuiElement(state);
 	}
 
 	public void requestCursor(CursorType pendingCursor) {

--- a/src/main/java/dev/lambdaurora/spruceui/render/state/ColoredRectangleRenderState.java
+++ b/src/main/java/dev/lambdaurora/spruceui/render/state/ColoredRectangleRenderState.java
@@ -15,7 +15,7 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.navigation.ScreenRectangle;
 import net.minecraft.client.gui.render.TextureSetup;
-import net.minecraft.client.gui.render.state.GuiElementRenderState;
+import net.minecraft.client.renderer.state.gui.GuiElementRenderState;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix3x2f;
 

--- a/src/main/java/dev/lambdaurora/spruceui/screen/SpruceHandledScreen.java
+++ b/src/main/java/dev/lambdaurora/spruceui/screen/SpruceHandledScreen.java
@@ -14,7 +14,7 @@ import dev.lambdaurora.spruceui.navigation.NavigationEvent;
 import dev.lambdaurora.spruceui.tooltip.Tooltip;
 import dev.lambdaurora.spruceui.widget.SpruceElement;
 import dev.lambdaurora.spruceui.widget.SpruceWidget;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.Renderable;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
@@ -45,10 +45,10 @@ public abstract class SpruceHandledScreen<T extends AbstractContainerMenu> exten
 		var old = this.getFocused();
 		if (old == focused) return;
 		if (old instanceof SpruceWidget)
-			((SpruceWidget) old).setFocused(false);
+			old.setFocused(false);
 		super.setFocused(focused);
 		if (focused instanceof SpruceWidget)
-			((SpruceWidget) focused).setFocused(true);
+			focused.setFocused(true);
 	}
 
 	/* Input */
@@ -105,20 +105,20 @@ public abstract class SpruceHandledScreen<T extends AbstractContainerMenu> exten
 	/* Render */
 
 	@Override
-	public void render(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
-		super.render(graphics, mouseX, mouseY, delta);
+	public void extractRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
+		super.extractRenderState(graphics, mouseX, mouseY, delta);
 		this.renderWidgets(graphics, mouseX, mouseY, delta);
 		this.renderTitle(graphics, mouseX, mouseY, delta);
 		Tooltip.renderAll(graphics);
 	}
 
-	public void renderTitle(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+	public void renderTitle(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
 	}
 
-	public void renderWidgets(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+	public void renderWidgets(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
 		for (var element : this.children()) {
 			if (element instanceof Renderable drawable)
-				drawable.render(graphics, mouseX, mouseY, delta);
+				drawable.extractRenderState(graphics, mouseX, mouseY, delta);
 		}
 	}
 }

--- a/src/main/java/dev/lambdaurora/spruceui/screen/SpruceHandledScreen.java
+++ b/src/main/java/dev/lambdaurora/spruceui/screen/SpruceHandledScreen.java
@@ -107,15 +107,15 @@ public abstract class SpruceHandledScreen<T extends AbstractContainerMenu> exten
 	@Override
 	public void extractRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
 		super.extractRenderState(graphics, mouseX, mouseY, delta);
-		this.renderWidgets(graphics, mouseX, mouseY, delta);
-		this.renderTitle(graphics, mouseX, mouseY, delta);
-		Tooltip.renderAll(graphics);
+		this.extractWidgets(graphics, mouseX, mouseY, delta);
+		this.extractTitle(graphics, mouseX, mouseY, delta);
+		Tooltip.extractAllRenderStates(graphics);
 	}
 
-	public void renderTitle(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
+	public void extractTitle(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
 	}
 
-	public void renderWidgets(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
+	public void extractWidgets(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
 		for (var element : this.children()) {
 			if (element instanceof Renderable drawable)
 				drawable.extractRenderState(graphics, mouseX, mouseY, delta);

--- a/src/main/java/dev/lambdaurora/spruceui/screen/SpruceScreen.java
+++ b/src/main/java/dev/lambdaurora/spruceui/screen/SpruceScreen.java
@@ -15,7 +15,7 @@ import dev.lambdaurora.spruceui.render.SpruceGuiGraphics;
 import dev.lambdaurora.spruceui.widget.SpruceElement;
 import dev.lambdaurora.spruceui.widget.SpruceRenderable;
 import dev.lambdaurora.spruceui.widget.SpruceWidget;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.input.KeyEvent;
@@ -102,16 +102,16 @@ public abstract class SpruceScreen extends Screen implements SprucePositioned, S
 	/* Render */
 
 	@Override
-	public final void render(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
-		this.render(SpruceGuiGraphics.of(graphics), mouseX, mouseY, delta);
+	public final void extractRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
+		this.extractRenderState(SpruceGuiGraphics.of(graphics), mouseX, mouseY, delta);
 	}
 
 	@Override
-	public void render(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+	public void extractRenderState(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
 		this.renderWidgets(graphics, mouseX, mouseY, delta);
 	}
 
 	public void renderWidgets(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
-		super.render(graphics.vanilla(), mouseX, mouseY, delta);
+		super.extractRenderState(graphics.vanilla(), mouseX, mouseY, delta);
 	}
 }

--- a/src/main/java/dev/lambdaurora/spruceui/screen/SpruceScreen.java
+++ b/src/main/java/dev/lambdaurora/spruceui/screen/SpruceScreen.java
@@ -108,10 +108,10 @@ public abstract class SpruceScreen extends Screen implements SprucePositioned, S
 
 	@Override
 	public void extractRenderState(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
-		this.renderWidgets(graphics, mouseX, mouseY, delta);
+		this.extractWidgets(graphics, mouseX, mouseY, delta);
 	}
 
-	public void renderWidgets(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+	public void extractWidgets(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
 		super.extractRenderState(graphics.vanilla(), mouseX, mouseY, delta);
 	}
 }

--- a/src/main/java/dev/lambdaurora/spruceui/tooltip/Tooltip.java
+++ b/src/main/java/dev/lambdaurora/spruceui/tooltip/Tooltip.java
@@ -16,7 +16,7 @@ import dev.lambdaurora.spruceui.event.ScreenEvents;
 import dev.lambdaurora.spruceui.tooltip.components.SpruceClientTooltipComponent;
 import dev.lambdaurora.spruceui.widget.SpruceWidget;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.navigation.ScreenRectangle;
 import net.minecraft.client.gui.screens.inventory.tooltip.BelowOrAboveWidgetTooltipPositioner;
 import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
@@ -69,10 +69,10 @@ public final class Tooltip implements SprucePositioned {
 	/**
 	 * Renders the tooltip.
 	 *
-	 * @param graphics The GuiGraphics instance used to render.
+	 * @param graphics The GuiGraphicsExtractor instance used to render.
 	 */
-	public void render(GuiGraphics graphics) {
-		graphics.renderTooltip(Minecraft.getInstance().font, this.components, this.x, this.y, this.positioner, this.style);
+	public void render(GuiGraphicsExtractor graphics) {
+		graphics.tooltip(Minecraft.getInstance().font, this.components, this.x, this.y, this.positioner, this.style);
 	}
 
 	/**
@@ -168,7 +168,7 @@ public final class Tooltip implements SprucePositioned {
 	 *
 	 * @param graphics the GUI graphics to render from
 	 */
-	public static void renderAll(GuiGraphics graphics) {
+	public static void renderAll(GuiGraphicsExtractor graphics) {
 		if (delayed)
 			return;
 		synchronized (TOOLTIPS) {

--- a/src/main/java/dev/lambdaurora/spruceui/tooltip/Tooltip.java
+++ b/src/main/java/dev/lambdaurora/spruceui/tooltip/Tooltip.java
@@ -71,7 +71,7 @@ public final class Tooltip implements SprucePositioned {
 	 *
 	 * @param graphics The GuiGraphicsExtractor instance used to render.
 	 */
-	public void render(GuiGraphicsExtractor graphics) {
+	public void extractRenderState(GuiGraphicsExtractor graphics) {
 		graphics.tooltip(Minecraft.getInstance().font, this.components, this.x, this.y, this.positioner, this.style);
 	}
 
@@ -168,14 +168,14 @@ public final class Tooltip implements SprucePositioned {
 	 *
 	 * @param graphics the GUI graphics to render from
 	 */
-	public static void renderAll(GuiGraphicsExtractor graphics) {
+	public static void extractAllRenderStates(GuiGraphicsExtractor graphics) {
 		if (delayed)
 			return;
 		synchronized (TOOLTIPS) {
 			Tooltip tooltip;
 
 			while ((tooltip = TOOLTIPS.poll()) != null)
-				tooltip.render(graphics);
+				tooltip.extractRenderState(graphics);
 		}
 	}
 
@@ -183,7 +183,7 @@ public final class Tooltip implements SprucePositioned {
 		var tooltipPhase = SpruceUI.id("tooltip");
 		ScreenEvents.AFTER_RENDER.addPhaseOrdering(ScreenEvents.AFTER_RENDER.defaultPhaseId(), tooltipPhase);
 		ScreenEvents.AFTER_RENDER.register(tooltipPhase,
-				(screen, graphics, mouseX, mouseY, tickDelta) -> renderAll(graphics.vanilla())
+				(screen, graphics, mouseX, mouseY, tickDelta) -> extractAllRenderStates(graphics.vanilla())
 		);
 	}
 }

--- a/src/main/java/dev/lambdaurora/spruceui/tooltip/components/ClientSpriteTooltipComponent.java
+++ b/src/main/java/dev/lambdaurora/spruceui/tooltip/components/ClientSpriteTooltipComponent.java
@@ -56,6 +56,6 @@ public record ClientSpriteTooltipComponent(
 			case RIGHT -> x + width - this.width;
 		};
 
-		graphics.drawSprite(RenderPipelines.GUI_TEXTURED, this.spriteId, actualX, y, this.width, this.height);
+		graphics.blitSprite(RenderPipelines.GUI_TEXTURED, this.spriteId, actualX, y, this.width, this.height);
 	}
 }

--- a/src/main/java/dev/lambdaurora/spruceui/tooltip/components/ClientSpriteTooltipComponent.java
+++ b/src/main/java/dev/lambdaurora/spruceui/tooltip/components/ClientSpriteTooltipComponent.java
@@ -49,7 +49,7 @@ public record ClientSpriteTooltipComponent(
 	}
 
 	@Override
-	public void renderImage(Font font, int x, int y, int width, int height, SpruceGuiGraphics graphics) {
+	public void extractImage(Font font, int x, int y, int width, int height, SpruceGuiGraphics graphics) {
 		int actualX = switch (this.alignment) {
 			case LEFT -> x;
 			case CENTER -> x + (width / 2 - this.width / 2);

--- a/src/main/java/dev/lambdaurora/spruceui/tooltip/components/ClientTextTooltipComponent.java
+++ b/src/main/java/dev/lambdaurora/spruceui/tooltip/components/ClientTextTooltipComponent.java
@@ -35,6 +35,6 @@ public record ClientTextTooltipComponent(FormattedCharSequence text) implements 
 
 	@Override
 	public void extractText(SpruceGuiGraphics graphics, Font font, int i, int j) {
-		graphics.drawText(font, this.text, i, j, ColorUtil.WHITE, true);
+		graphics.text(font, this.text, i, j, ColorUtil.WHITE, true);
 	}
 }

--- a/src/main/java/dev/lambdaurora/spruceui/tooltip/components/ClientTextTooltipComponent.java
+++ b/src/main/java/dev/lambdaurora/spruceui/tooltip/components/ClientTextTooltipComponent.java
@@ -34,7 +34,7 @@ public record ClientTextTooltipComponent(FormattedCharSequence text) implements 
 	}
 
 	@Override
-	public void renderText(SpruceGuiGraphics graphics, Font font, int i, int j) {
+	public void extractText(SpruceGuiGraphics graphics, Font font, int i, int j) {
 		graphics.drawText(font, this.text, i, j, ColorUtil.WHITE, true);
 	}
 }

--- a/src/main/java/dev/lambdaurora/spruceui/tooltip/components/ClientThumbnailTooltipComponent.java
+++ b/src/main/java/dev/lambdaurora/spruceui/tooltip/components/ClientThumbnailTooltipComponent.java
@@ -62,10 +62,10 @@ public record ClientThumbnailTooltipComponent(
 	}
 
 	@Override
-	public void renderText(SpruceGuiGraphics graphics, Font font, int x, int y) {
+	public void extractText(SpruceGuiGraphics graphics, Font font, int x, int y) {
 		var layout = this.getLayout(font);
 
-		this.thumbnailComponent.renderText(graphics, font, x, y + layout.thumbnailYOffset());
+		this.thumbnailComponent.extractText(graphics, font, x, y + layout.thumbnailYOffset());
 
 		int sideY = y;
 		for (var line : layout.sideLines) {
@@ -81,10 +81,10 @@ public record ClientThumbnailTooltipComponent(
 	}
 
 	@Override
-	public void renderImage(Font font, int x, int y, int width, int height, SpruceGuiGraphics graphics) {
+	public void extractImage(Font font, int x, int y, int width, int height, SpruceGuiGraphics graphics) {
 		var layout = this.getLayout(font);
 
-		this.thumbnailComponent.renderImage(
+		this.thumbnailComponent.extractImage(
 				font,
 				x, y + layout.thumbnailYOffset(),
 				layout.thumbnailWidth, layout.thumbnailHeight,

--- a/src/main/java/dev/lambdaurora/spruceui/tooltip/components/ClientThumbnailTooltipComponent.java
+++ b/src/main/java/dev/lambdaurora/spruceui/tooltip/components/ClientThumbnailTooltipComponent.java
@@ -69,13 +69,13 @@ public record ClientThumbnailTooltipComponent(
 
 		int sideY = y;
 		for (var line : layout.sideLines) {
-			graphics.drawText(font, line, x + layout.thumbnailWidth + 2, sideY, ColorUtil.WHITE, true);
+			graphics.text(font, line, x + layout.thumbnailWidth + 2, sideY, ColorUtil.WHITE, true);
 			sideY += font.lineHeight + 1;
 		}
 
 		int belowY = y + layout.belowLinesY;
 		for (var line : layout.belowLines) {
-			graphics.drawText(font, line, x, belowY, ColorUtil.WHITE, true);
+			graphics.text(font, line, x, belowY, ColorUtil.WHITE, true);
 			belowY += font.lineHeight + 1;
 		}
 	}

--- a/src/main/java/dev/lambdaurora/spruceui/tooltip/components/SpruceClientTooltipComponent.java
+++ b/src/main/java/dev/lambdaurora/spruceui/tooltip/components/SpruceClientTooltipComponent.java
@@ -11,7 +11,7 @@ package dev.lambdaurora.spruceui.tooltip.components;
 
 import dev.lambdaurora.spruceui.render.SpruceGuiGraphics;
 import net.minecraft.client.gui.Font;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
 
 /**
@@ -22,22 +22,22 @@ import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent
  * @since 8.0.0
  */
 public interface SpruceClientTooltipComponent extends ClientTooltipComponent {
-	default void renderText(SpruceGuiGraphics graphics, Font font, int x, int y) {
+	default void extractText(SpruceGuiGraphics graphics, Font font, int x, int y) {
 	}
 
-	default void renderImage(
+	default void extractImage(
 			Font font, int x, int y, int width, int height, SpruceGuiGraphics graphics
 	) {
 	}
 
 	@Override
-	default void renderText(GuiGraphics graphics, Font font, int x, int y) {
-		this.renderText(SpruceGuiGraphics.of(graphics), font, x, y);
+	default void extractText(GuiGraphicsExtractor graphics, Font font, int x, int y) {
+		this.extractText(SpruceGuiGraphics.of(graphics), font, x, y);
 	}
 
 	@Override
-	default void renderImage(Font font, int x, int y, int width, int height, GuiGraphics graphics) {
-		this.renderImage(font, x, y, width, height, SpruceGuiGraphics.of(graphics));
+	default void extractImage(Font font, int x, int y, int width, int height, GuiGraphicsExtractor graphics) {
+		this.extractImage(font, x, y, width, height, SpruceGuiGraphics.of(graphics));
 	}
 
 	/**
@@ -76,15 +76,15 @@ public interface SpruceClientTooltipComponent extends ClientTooltipComponent {
 				}
 
 				@Override
-				public void renderText(SpruceGuiGraphics graphics, Font font, int x, int y) {
-					component.renderText(graphics.vanilla(), font, x, y);
+				public void extractText(SpruceGuiGraphics graphics, Font font, int x, int y) {
+					component.extractText(graphics.vanilla(), font, x, y);
 				}
 
 				@Override
-				public void renderImage(
+				public void extractImage(
 						Font font, int x, int y, int width, int height, SpruceGuiGraphics graphics
 				) {
-					component.renderImage(font, x, y, width, height, graphics.vanilla());
+					component.extractImage(font, x, y, width, height, graphics.vanilla());
 				}
 			};
 		}

--- a/src/main/java/dev/lambdaurora/spruceui/util/RenderUtil.java
+++ b/src/main/java/dev/lambdaurora/spruceui/util/RenderUtil.java
@@ -24,12 +24,12 @@ public final class RenderUtil {
 	 * @param width the width
 	 * @param height the height
 	 * @param vOffset the v offset
-	 * @see #renderBackgroundTexture(SpruceGuiGraphics, int, int, int, int, float, int, int, int, int)
+	 * @see #extractBackgroundTexture(SpruceGuiGraphics, int, int, int, int, float, int, int, int, int)
 	 */
-	public static void renderBackgroundTexture(
+	public static void extractBackgroundTexture(
 			SpruceGuiGraphics graphics, int x, int y, int width, int height, float vOffset
 	) {
-		renderBackgroundTexture(graphics, x, y, width, height, vOffset, 64, 64, 64, 255);
+		extractBackgroundTexture(graphics, x, y, width, height, vOffset, 64, 64, 64, 255);
 	}
 
 	/**
@@ -45,7 +45,7 @@ public final class RenderUtil {
 	 * @param blue the blue-component color value
 	 * @param alpha the alpha-component alpha value
 	 */
-	public static void renderBackgroundTexture(
+	public static void extractBackgroundTexture(
 			SpruceGuiGraphics graphics,
 			int x, int y, int width, int height, float vOffset,
 			int red, int green, int blue, int alpha

--- a/src/main/java/dev/lambdaurora/spruceui/widget/AbstractSpruceButtonWidget.java
+++ b/src/main/java/dev/lambdaurora/spruceui/widget/AbstractSpruceButtonWidget.java
@@ -16,7 +16,7 @@ import dev.lambdaurora.spruceui.tooltip.Tooltip;
 import dev.lambdaurora.spruceui.tooltip.TooltipData;
 import dev.lambdaurora.spruceui.tooltip.Tooltipable;
 import dev.lambdaurora.spruceui.wrapper.VanillaButtonWrapper;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.WidgetSprites;
 import net.minecraft.client.gui.narration.NarratedElementType;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
@@ -174,7 +174,7 @@ public abstract class AbstractSpruceButtonWidget extends AbstractSpruceWidget im
 		int margin = 2;
 		int startX = this.getX() + margin;
 		int endX = this.getX() + this.getWidth() - margin;
-		var collector = graphics.textRenderer(this.alpha, GuiGraphics.HoveredTextEffects.NONE);
+		var collector = graphics.textRenderer(this.alpha, GuiGraphicsExtractor.HoveredTextEffects.NONE);
 		collector.acceptScrolling(this.getMessage(),
 				this.getX() + this.getWidth() / 2, startX, endX,
 				this.getY(), this.getY() + this.getHeight()

--- a/src/main/java/dev/lambdaurora/spruceui/widget/AbstractSpruceButtonWidget.java
+++ b/src/main/java/dev/lambdaurora/spruceui/widget/AbstractSpruceButtonWidget.java
@@ -153,8 +153,8 @@ public abstract class AbstractSpruceButtonWidget extends AbstractSpruceWidget im
 	}
 
 	@Override
-	protected void renderWidget(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
-		this.renderButton(graphics, mouseX, mouseY, delta);
+	protected void extractWidgetRenderState(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+		this.extractButton(graphics, mouseX, mouseY, delta);
 
 		if (this.isMouseHovered()) {
 			graphics.requestCursor(this.isActive() ? CursorTypes.POINTING_HAND : CursorTypes.NOT_ALLOWED);
@@ -165,12 +165,12 @@ public abstract class AbstractSpruceButtonWidget extends AbstractSpruceWidget im
 					i -> this.tooltipTicks = i, this.lastTick, i -> this.lastTick = i);
 	}
 
-	protected void renderButton(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+	protected void extractButton(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
 		int color = this.active ? 16777215 : 10526880;
-		this.renderText(graphics, color | Mth.ceil(this.alpha * 255.0F) << 24);
+		this.extractText(graphics, color | Mth.ceil(this.alpha * 255.0F) << 24);
 	}
 
-	protected void renderText(SpruceGuiGraphics graphics, int color) {
+	protected void extractText(SpruceGuiGraphics graphics, int color) {
 		int margin = 2;
 		int startX = this.getX() + margin;
 		int endX = this.getX() + this.getWidth() - margin;
@@ -182,8 +182,8 @@ public abstract class AbstractSpruceButtonWidget extends AbstractSpruceWidget im
 	}
 
 	@Override
-	protected void renderBackground(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
-		graphics.drawSprite(RenderPipelines.GUI_TEXTURED, this.getTexture(), this.getX(), this.getY(), this.getWidth(), this.getHeight());
+	protected void extractBackground(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+		graphics.blitSprite(RenderPipelines.GUI_TEXTURED, this.getTexture(), this.getX(), this.getY(), this.getWidth(), this.getHeight());
 	}
 
 	/* Narration */

--- a/src/main/java/dev/lambdaurora/spruceui/widget/AbstractSpruceIconButtonWidget.java
+++ b/src/main/java/dev/lambdaurora/spruceui/widget/AbstractSpruceIconButtonWidget.java
@@ -27,11 +27,11 @@ public abstract class AbstractSpruceIconButtonWidget extends SpruceButtonWidget 
 	protected abstract int renderIcon(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta);
 
 	@Override
-	protected void renderButton(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+	protected void extractButton(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
 		int iconWidth = this.renderIcon(graphics, mouseX, mouseY, delta);
 		if (!this.getMessage().getString().isEmpty()) {
 			int color = this.isActive() ? 16777215 : 10526880;
-			graphics.drawCenteredShadowedText(this.client.font, this.getMessage(),
+			graphics.centeredShadowedText(this.client.font, this.getMessage(),
 					this.getX() + 8 + iconWidth + (this.getWidth() - 8 - iconWidth - 6) / 2,
 					this.getY() + (this.height - 8) / 2, color | Mth.ceil(this.getAlpha() * 255.0F) << 24);
 		}

--- a/src/main/java/dev/lambdaurora/spruceui/widget/AbstractSpruceWidget.java
+++ b/src/main/java/dev/lambdaurora/spruceui/widget/AbstractSpruceWidget.java
@@ -13,7 +13,7 @@ import dev.lambdaurora.spruceui.Position;
 import dev.lambdaurora.spruceui.navigation.NavigationEvent;
 import dev.lambdaurora.spruceui.render.SpruceGuiGraphics;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.narration.NarratedElementType;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.client.input.CharacterEvent;
@@ -248,11 +248,11 @@ public abstract class AbstractSpruceWidget implements SpruceWidget {
 	/* Rendering */
 
 	@Override
-	public final void render(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
-		this.render(new SpruceGuiGraphics(graphics), mouseX, mouseY, delta);
+	public final void extractRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
+		this.extractRenderState(new SpruceGuiGraphics(graphics), mouseX, mouseY, delta);
 	}
 
-	public void render(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+	public void extractRenderState(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
 		if (this.isVisible()) {
 			this.hovered = mouseX >= this.getX() && mouseY >= this.getY()
 					&& mouseX < this.getX() + this.getWidth() && mouseY < this.getY() + this.getHeight();

--- a/src/main/java/dev/lambdaurora/spruceui/widget/AbstractSpruceWidget.java
+++ b/src/main/java/dev/lambdaurora/spruceui/widget/AbstractSpruceWidget.java
@@ -263,8 +263,8 @@ public abstract class AbstractSpruceWidget implements SpruceWidget {
 				}
 			}
 
-			this.renderBackground(graphics, mouseX, mouseY, delta);
-			this.renderWidget(graphics, mouseX, mouseY, delta);
+			this.extractBackground(graphics, mouseX, mouseY, delta);
+			this.extractWidgetRenderState(graphics, mouseX, mouseY, delta);
 
 			this.wasHovered = this.isMouseHovered();
 		} else {
@@ -280,7 +280,7 @@ public abstract class AbstractSpruceWidget implements SpruceWidget {
 	 * @param mouseY the mouse Y-coordinate
 	 * @param delta the tick delta
 	 */
-	protected abstract void renderWidget(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta);
+	protected abstract void extractWidgetRenderState(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta);
 
 	/**
 	 * Renders the background of the widget.
@@ -290,7 +290,7 @@ public abstract class AbstractSpruceWidget implements SpruceWidget {
 	 * @param mouseY the mouse Y-coordinate
 	 * @param delta the tick delta
 	 */
-	protected void renderBackground(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+	protected void extractBackground(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
 	}
 
 	/* Sound */

--- a/src/main/java/dev/lambdaurora/spruceui/widget/SpruceCheckboxWidget.java
+++ b/src/main/java/dev/lambdaurora/spruceui/widget/SpruceCheckboxWidget.java
@@ -91,16 +91,16 @@ public class SpruceCheckboxWidget extends AbstractSpruceBooleanButtonWidget {
 	/* Rendering */
 
 	@Override
-	protected void renderButton(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+	protected void extractButton(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
 		if (this.getValue()) {
-			graphics.drawSprite(
+			graphics.blitSprite(
 					RenderPipelines.GUI_TEXTURED, CHECKED_TEXTURE,
 					this.getX(), this.getY(),
 					this.getHeight(), this.getHeight(),
 					this.colored ? 0xff00ff00 : -1
 			);
 		} else if (this.showCross) {
-			graphics.drawSprite(
+			graphics.blitSprite(
 					RenderPipelines.GUI_TEXTURED, CROSSED_TEXTURE,
 					this.getX(), this.getY(),
 					this.getHeight(), this.getHeight(),
@@ -112,7 +112,7 @@ public class SpruceCheckboxWidget extends AbstractSpruceBooleanButtonWidget {
 			var message = Language.getInstance().getVisualOrder(
 					this.client.font.substrByWidth(this.getMessage(), this.getWidth() - this.getHeight() - 4)
 			);
-			graphics.drawShadowedText(this.client.font, message,
+			graphics.shadowedText(this.client.font, message,
 					this.getX() + this.getHeight() + 4, this.getY() + (this.getHeight() - 8) / 2,
 					0xe0e0e0 | Mth.ceil(this.alpha * 255.0F) << 24
 			);
@@ -120,8 +120,8 @@ public class SpruceCheckboxWidget extends AbstractSpruceBooleanButtonWidget {
 	}
 
 	@Override
-	protected void renderBackground(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
-		graphics.drawSprite(
+	protected void extractBackground(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+		graphics.blitSprite(
 				RenderPipelines.GUI_TEXTURED, BACKGROUND_TEXTURE.get(this.isActive(), this.isFocusedOrHovered()),
 				this.getX(), this.getY(),
 				this.getHeight(), this.getHeight()

--- a/src/main/java/dev/lambdaurora/spruceui/widget/SpruceLabelWidget.java
+++ b/src/main/java/dev/lambdaurora/spruceui/widget/SpruceLabelWidget.java
@@ -42,9 +42,9 @@ public class SpruceLabelWidget extends AbstractSpruceWidget implements Tooltipab
 	private List<FormattedCharSequence> lines;
 	private SpruceTextAlignment alignment;
 	private int color = ColorUtil.WHITE;
-	private int maxWidth;
+	private final int maxWidth;
 	private final Consumer<SpruceLabelWidget> action;
-	private int baseX;
+	private final int baseX;
 	//private final int                         maxHeight;
 
 	private TooltipData tooltip = TooltipData.EMPTY;
@@ -213,7 +213,7 @@ public class SpruceLabelWidget extends AbstractSpruceWidget implements Tooltipab
 	/* Rendering */
 
 	@Override
-	protected void renderWidget(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+	protected void extractWidgetRenderState(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
 		int y = this.getY() + 2;
 		for (var it = this.lines.iterator(); it.hasNext(); y += 9) {
 			var line = it.next();
@@ -222,10 +222,10 @@ public class SpruceLabelWidget extends AbstractSpruceWidget implements Tooltipab
 				case CENTER -> (this.getInnerX() + this.maxWidth / 2) - this.client.font.width(line) / 2;
 				case RIGHT -> this.getInnerX() + this.maxWidth - this.client.font.width(line);
 			};
-			graphics.drawShadowedText(this.client.font, line, x, y, this.color);
+			graphics.shadowedText(this.client.font, line, x, y, this.color);
 		}
 
-		this.getBorder().render(graphics, this, mouseX, mouseY, delta);
+		this.getBorder().extractRenderState(graphics, this, mouseX, mouseY, delta);
 
 		if (!this.dragging) {
 			Tooltip.queueFor(this, mouseX, mouseY, this.tooltipTicks,

--- a/src/main/java/dev/lambdaurora/spruceui/widget/SpruceRenderable.java
+++ b/src/main/java/dev/lambdaurora/spruceui/widget/SpruceRenderable.java
@@ -10,7 +10,7 @@
 package dev.lambdaurora.spruceui.widget;
 
 import dev.lambdaurora.spruceui.render.SpruceGuiGraphics;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.Renderable;
 
 /**
@@ -29,10 +29,10 @@ public interface SpruceRenderable extends Renderable {
 	 * @param mouseY the Y-coordinate of the mouse cursor
 	 * @param tickDelta the partial tick time
 	 */
-	void render(SpruceGuiGraphics graphics, int mouseX, int mouseY, float tickDelta);
+	void extractRenderState(SpruceGuiGraphics graphics, int mouseX, int mouseY, float tickDelta);
 
-	@Override
-	default void render(GuiGraphics graphics, int mouseX, int mouseY, float tickDelta) {
-		this.render(SpruceGuiGraphics.of(graphics), mouseX, mouseY, tickDelta);
+
+	default void extractRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float tickDelta) {
+		this.extractRenderState(SpruceGuiGraphics.of(graphics), mouseX, mouseY, tickDelta);
 	}
 }

--- a/src/main/java/dev/lambdaurora/spruceui/widget/SpruceSeparatorWidget.java
+++ b/src/main/java/dev/lambdaurora/spruceui/widget/SpruceSeparatorWidget.java
@@ -117,7 +117,7 @@ public class SpruceSeparatorWidget extends AbstractSpruceWidget implements Toolt
 	/* Rendering */
 
 	@Override
-	protected void renderWidget(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+	protected void extractWidgetRenderState(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
 		int lineY = this.getY() + this.getHeight() / 2 - 1;
 
 		if (this.title != null) {
@@ -129,7 +129,7 @@ public class SpruceSeparatorWidget extends AbstractSpruceWidget implements Toolt
 			int y = this.getY();
 			for (var line : this.titleToRender) {
 				int lineX = this.getX() + (this.getWidth() / 2 - this.client.font.width(line) / 2);
-				graphics.drawShadowedText(this.client.font, line, lineX, y, ColorUtil.WHITE);
+				graphics.shadowedText(this.client.font, line, lineX, y, ColorUtil.WHITE);
 				y += 2 + this.client.font.lineHeight;
 			}
 		} else {

--- a/src/main/java/dev/lambdaurora/spruceui/widget/SpruceSliderWidget.java
+++ b/src/main/java/dev/lambdaurora/spruceui/widget/SpruceSliderWidget.java
@@ -32,8 +32,8 @@ public class SpruceSliderWidget extends AbstractSpruceButtonWidget implements To
 	private Component baseMessage;
 	protected double value;
 	private final Consumer<SpruceSliderWidget> applyConsumer;
-	private double multiplier;
-	private String sign;
+	private final double multiplier;
+	private final String sign;
 	private boolean inUse = false;
 
 	private static final Identifier SLIDER = Identifier.withDefaultNamespace("widget/slider");
@@ -170,9 +170,9 @@ public class SpruceSliderWidget extends AbstractSpruceButtonWidget implements To
 	}
 
 	@Override
-	protected void renderButton(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+	protected void extractButton(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
 		final Identifier texture = this.isFocusedOrHovered() ? SLIDER_HANDLE_HIGHLIGHTED : SLIDER_HANDLE;
-		graphics.drawSprite(
+		graphics.blitSprite(
 				RenderPipelines.GUI_TEXTURED,
 				texture,
 				this.getX() + (int) (this.value * (double) (this.getWidth() - 8)), this.getY(),
@@ -183,7 +183,7 @@ public class SpruceSliderWidget extends AbstractSpruceButtonWidget implements To
 			this.inUse = false;
 		}
 
-		super.renderButton(graphics, mouseX, mouseY, delta);
+		super.extractButton(graphics, mouseX, mouseY, delta);
 	}
 
 	/* Narration */

--- a/src/main/java/dev/lambdaurora/spruceui/widget/SpruceTexturedButtonWidget.java
+++ b/src/main/java/dev/lambdaurora/spruceui/widget/SpruceTexturedButtonWidget.java
@@ -61,19 +61,19 @@ public class SpruceTexturedButtonWidget extends SpruceButtonWidget {
 	/* Rendering */
 
 	@Override
-	protected void renderButton(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+	protected void extractButton(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
 		if (this.showMessage)
-			super.renderButton(graphics, mouseX, mouseY, delta);
+			super.extractButton(graphics, mouseX, mouseY, delta);
 	}
 
 	@Override
-	protected void renderBackground(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+	protected void extractBackground(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
 		int v = this.v;
 		if (this.isFocusedOrHovered()) {
 			v += this.hoveredVOffset;
 		}
 
-		graphics.drawTexture(
+		graphics.blit(
 				RenderPipelines.GUI_TEXTURED, this.texture,
 				this.getX(), this.getY(),
 				this.u, v,

--- a/src/main/java/dev/lambdaurora/spruceui/widget/SpruceToggleSwitch.java
+++ b/src/main/java/dev/lambdaurora/spruceui/widget/SpruceToggleSwitch.java
@@ -62,8 +62,8 @@ public class SpruceToggleSwitch extends AbstractSpruceBooleanButtonWidget {
 	/* Rendering */
 
 	@Override
-	protected void renderButton(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
-		graphics.drawSprite(
+	protected void extractButton(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+		graphics.blitSprite(
 				RenderPipelines.GUI_TEXTURED, (this.getValue() ? ON_TEXTURE : OFF_TEXTURE).get(this.isActive(), this.isFocusedOrHovered()),
 				this.getX() + (this.getValue() ? 14 : 0), this.getY() + (this.getHeight() / 2 - 9),
 				18, 18
@@ -73,14 +73,14 @@ public class SpruceToggleSwitch extends AbstractSpruceBooleanButtonWidget {
 			var message = Language.getInstance().getVisualOrder(
 					this.client.font.substrByWidth(this.getMessage(), this.getWidth() - 40)
 			);
-			graphics.drawShadowedText(this.client.font, message, this.getX() + 36, this.getY() + (this.getHeight() - 8) / 2,
+			graphics.shadowedText(this.client.font, message, this.getX() + 36, this.getY() + (this.getHeight() - 8) / 2,
 					14737632 | Mth.ceil(this.alpha * 255.0F) << 24);
 		}
 	}
 
 	@Override
-	protected void renderBackground(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
-		graphics.drawSprite(
+	protected void extractBackground(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+		graphics.blitSprite(
 				RenderPipelines.GUI_TEXTURED, BACKGROUND_TEXTURE.get(this.isActive(), this.isFocusedOrHovered()),
 				this.getX(), this.getY() + (this.getHeight() / 2 - 9),
 				32, 18

--- a/src/main/java/dev/lambdaurora/spruceui/widget/container/SpruceContainerWidget.java
+++ b/src/main/java/dev/lambdaurora/spruceui/widget/container/SpruceContainerWidget.java
@@ -79,7 +79,7 @@ public class SpruceContainerWidget extends AbstractSpruceParentWidget<SpruceWidg
 
 	@Override
 	protected void renderWidget(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
-		this.forEach(child -> child.render(graphics, mouseX, mouseY, delta));
+		this.forEach(child -> child.extractRenderState(graphics, mouseX, mouseY, delta));
 		this.getBorder().render(graphics, this, mouseX, mouseY, delta);
 	}
 

--- a/src/main/java/dev/lambdaurora/spruceui/widget/container/SpruceContainerWidget.java
+++ b/src/main/java/dev/lambdaurora/spruceui/widget/container/SpruceContainerWidget.java
@@ -78,14 +78,14 @@ public class SpruceContainerWidget extends AbstractSpruceParentWidget<SpruceWidg
 	/* Rendering */
 
 	@Override
-	protected void renderWidget(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+	protected void extractWidgetRenderState(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
 		this.forEach(child -> child.extractRenderState(graphics, mouseX, mouseY, delta));
-		this.getBorder().render(graphics, this, mouseX, mouseY, delta);
+		this.getBorder().extractRenderState(graphics, this, mouseX, mouseY, delta);
 	}
 
 	@Override
-	protected void renderBackground(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
-		this.getBackground().render(graphics, this, 0, mouseX, mouseY, delta);
+	protected void extractBackground(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+		this.getBackground().extractRenderState(graphics, this, 0, mouseX, mouseY, delta);
 	}
 
 	public interface ChildrenFactory {

--- a/src/main/java/dev/lambdaurora/spruceui/widget/container/SpruceEntryListWidget.java
+++ b/src/main/java/dev/lambdaurora/spruceui/widget/container/SpruceEntryListWidget.java
@@ -341,12 +341,12 @@ public abstract class SpruceEntryListWidget<E extends SpruceEntryListWidget.Entr
 	/* Rendering */
 
 	@Override
-	protected void renderBackground(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
-		this.getBackground().render(graphics, this, 0, mouseX, mouseY, delta);
+	protected void extractBackground(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+		this.getBackground().extractRenderState(graphics, this, 0, mouseX, mouseY, delta);
 	}
 
 	@Override
-	protected void renderWidget(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+	protected void extractWidgetRenderState(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
 		int left = this.getInnerBorderedX();
 		int right = this.getEndInnerBorderedX();
 		int top = this.getInnerBorderedY();
@@ -368,12 +368,12 @@ public abstract class SpruceEntryListWidget<E extends SpruceEntryListWidget.Entr
 		}
 
 		// Scrollbar
-		this.renderScrollbar(graphics, mouseX, mouseY);
+		this.extractScrollbar(graphics, mouseX, mouseY);
 
-		this.getBorder().render(graphics, this, mouseX, mouseY, delta);
+		this.getBorder().extractRenderState(graphics, this, mouseX, mouseY, delta);
 	}
 
-	protected void renderScrollbar(SpruceGuiGraphics graphics, int mouseX, int mouseY) {
+	protected void extractScrollbar(SpruceGuiGraphics graphics, int mouseX, int mouseY) {
 		if (this.isScrollbarVisible()) {
 			int top = this.getInnerBorderedY();
 			int height = this.getInnerBorderedHeight();
@@ -385,10 +385,10 @@ public abstract class SpruceEntryListWidget<E extends SpruceEntryListWidget.Entr
 				scrollbarY = top;
 			}
 
-			graphics.drawSprite(RenderPipelines.GUI_TEXTURED, SpruceTextures.SCROLLER_BACKGROUND,
+			graphics.blitSprite(RenderPipelines.GUI_TEXTURED, SpruceTextures.SCROLLER_BACKGROUND,
 					scrollbarX, top, 6, this.getInnerBorderedHeight()
 			);
-			graphics.drawSprite(RenderPipelines.GUI_TEXTURED, SpruceTextures.SCROLLER,
+			graphics.blitSprite(RenderPipelines.GUI_TEXTURED, SpruceTextures.SCROLLER,
 					scrollbarX, scrollbarY, 6, scrollerHeight
 			);
 

--- a/src/main/java/dev/lambdaurora/spruceui/widget/container/SpruceEntryListWidget.java
+++ b/src/main/java/dev/lambdaurora/spruceui/widget/container/SpruceEntryListWidget.java
@@ -353,7 +353,7 @@ public abstract class SpruceEntryListWidget<E extends SpruceEntryListWidget.Entr
 		int bottom = this.getEndInnerBorderedY();
 
 		graphics.enableScissor(left, top, right, bottom);
-		this.entries.forEach(e -> e.render(graphics, mouseX, mouseY, delta));
+		this.entries.forEach(e -> e.extractRenderState(graphics, mouseX, mouseY, delta));
 		graphics.disableScissor();
 
 		// Render the transition thingy.

--- a/src/main/java/dev/lambdaurora/spruceui/widget/container/SpruceOptionListWidget.java
+++ b/src/main/java/dev/lambdaurora/spruceui/widget/container/SpruceOptionListWidget.java
@@ -225,7 +225,7 @@ public class SpruceOptionListWidget extends SpruceEntryListWidget<SpruceOptionLi
 
 		@Override
 		protected void renderWidget(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
-			this.forEach(widget -> widget.render(graphics, mouseX, mouseY, delta));
+			this.forEach(widget -> widget.extractRenderState(graphics, mouseX, mouseY, delta));
 		}
 
 		/* Narration */

--- a/src/main/java/dev/lambdaurora/spruceui/widget/container/SpruceOptionListWidget.java
+++ b/src/main/java/dev/lambdaurora/spruceui/widget/container/SpruceOptionListWidget.java
@@ -224,7 +224,7 @@ public class SpruceOptionListWidget extends SpruceEntryListWidget<SpruceOptionLi
 		/* Rendering */
 
 		@Override
-		protected void renderWidget(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+		protected void extractWidgetRenderState(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
 			this.forEach(widget -> widget.extractRenderState(graphics, mouseX, mouseY, delta));
 		}
 

--- a/src/main/java/dev/lambdaurora/spruceui/widget/container/tabbed/SpruceTabbedWidget.java
+++ b/src/main/java/dev/lambdaurora/spruceui/widget/container/tabbed/SpruceTabbedWidget.java
@@ -174,12 +174,12 @@ public class SpruceTabbedWidget extends AbstractSpruceParentWidget<SpruceWidget>
 	/* Render */
 
 	@Override
-	protected void renderWidget(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+	protected void extractWidgetRenderState(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
 		if (this.title != null) {
 			int y = this.getY() + 6;
 			for (var it = this.title.iterator(); it.hasNext(); y += 9) {
 				var line = it.next();
-				graphics.drawCenteredShadowedText(
+				graphics.centeredShadowedText(
 						this.client.font, line, this.getX() + this.list.getWidth() / 2, y, ColorUtil.WHITE
 				);
 			}
@@ -226,8 +226,8 @@ public class SpruceTabbedWidget extends AbstractSpruceParentWidget<SpruceWidget>
 		/* Rendering */
 
 		@Override
-		protected void renderBackground(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
-			this.getBackground().render(graphics, this, 0, mouseX, mouseY, delta);
+		protected void extractBackground(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+			this.getBackground().extractRenderState(graphics, this, 0, mouseX, mouseY, delta);
 		}
 	}
 
@@ -281,17 +281,17 @@ public class SpruceTabbedWidget extends AbstractSpruceParentWidget<SpruceWidget>
 		/* Render */
 
 		@Override
-		protected void renderWidget(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+		protected void extractWidgetRenderState(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
 			int y = this.getY() + 4;
 			for (var it = this.title.iterator(); it.hasNext(); y += 9) {
 				var line = it.next();
-				graphics.drawText(this.client.font, line, this.getX() + 4, y, ColorUtil.WHITE, false);
+				graphics.text(this.client.font, line, this.getX() + 4, y, ColorUtil.WHITE, false);
 			}
 			if (this.description != null) {
 				y += 4;
 				for (var it = this.description.iterator(); it.hasNext(); y += 9) {
 					var line = it.next();
-					graphics.drawText(this.client.font, line, this.getX() + 8, y, ColorUtil.WHITE, false);
+					graphics.text(this.client.font, line, this.getX() + 8, y, ColorUtil.WHITE, false);
 				}
 			}
 
@@ -301,8 +301,8 @@ public class SpruceTabbedWidget extends AbstractSpruceParentWidget<SpruceWidget>
 		}
 
 		@Override
-		protected void renderBackground(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
-			super.renderBackground(graphics, mouseX, mouseY, delta);
+		protected void extractBackground(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+			super.extractBackground(graphics, mouseX, mouseY, delta);
 			if (this.isFocused() && this.parent.isFocused())
 				graphics.fill(this.getX(), this.getY(),
 						this.getX() + this.getWidth(),
@@ -361,7 +361,7 @@ public class SpruceTabbedWidget extends AbstractSpruceParentWidget<SpruceWidget>
 		/* Rendering */
 
 		@Override
-		protected void renderWidget(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+		protected void extractWidgetRenderState(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
 			this.separatorWidget.extractRenderState(graphics, mouseX, mouseY, delta);
 		}
 

--- a/src/main/java/dev/lambdaurora/spruceui/widget/container/tabbed/SpruceTabbedWidget.java
+++ b/src/main/java/dev/lambdaurora/spruceui/widget/container/tabbed/SpruceTabbedWidget.java
@@ -184,9 +184,9 @@ public class SpruceTabbedWidget extends AbstractSpruceParentWidget<SpruceWidget>
 				);
 			}
 		}
-		this.list.render(graphics, mouseX, mouseY, delta);
+		this.list.extractRenderState(graphics, mouseX, mouseY, delta);
 		if (this.list.getCurrentTab() != null)
-			this.list.getCurrentTab().container.render(graphics, mouseX, mouseY, delta);
+			this.list.getCurrentTab().container.extractRenderState(graphics, mouseX, mouseY, delta);
 	}
 
 	public static abstract class Entry extends SpruceEntryListWidget.Entry implements WithBackground {
@@ -362,7 +362,7 @@ public class SpruceTabbedWidget extends AbstractSpruceParentWidget<SpruceWidget>
 
 		@Override
 		protected void renderWidget(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
-			this.separatorWidget.render(graphics, mouseX, mouseY, delta);
+			this.separatorWidget.extractRenderState(graphics, mouseX, mouseY, delta);
 		}
 
 		@Override

--- a/src/main/java/dev/lambdaurora/spruceui/widget/text/AbstractSpruceTextInputWidget.java
+++ b/src/main/java/dev/lambdaurora/spruceui/widget/text/AbstractSpruceTextInputWidget.java
@@ -231,8 +231,8 @@ public abstract class AbstractSpruceTextInputWidget<C extends AbstractSpruceText
 	/* Rendering */
 
 	@Override
-	protected void renderWidget(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
-		this.getBorder().render(graphics, this, mouseX, mouseY, delta);
+	protected void extractWidgetRenderState(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+		this.getBorder().extractRenderState(graphics, this, mouseX, mouseY, delta);
 
 		if (this.isMouseHovered()) {
 			graphics.requestCursor(this.isEditable() ? CursorTypes.IBEAM : CursorTypes.NOT_ALLOWED);
@@ -240,8 +240,8 @@ public abstract class AbstractSpruceTextInputWidget<C extends AbstractSpruceText
 	}
 
 	@Override
-	protected void renderBackground(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
-		this.getBackground().render(graphics, this, 0, mouseX, mouseY, delta);
+	protected void extractBackground(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+		this.getBackground().extractRenderState(graphics, this, 0, mouseX, mouseY, delta);
 	}
 
 	/* Narration */

--- a/src/main/java/dev/lambdaurora/spruceui/widget/text/SpruceNamedTextFieldWidget.java
+++ b/src/main/java/dev/lambdaurora/spruceui/widget/text/SpruceNamedTextFieldWidget.java
@@ -224,8 +224,8 @@ public class SpruceNamedTextFieldWidget extends AbstractSpruceWidget implements 
 	/* Rendering */
 
 	@Override
-	protected void renderWidget(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
-		graphics.drawShadowedText(this.client.font, this.getTextFieldWidget().getTitle(), this.getX() + 2, this.getY() + 2, ColorUtil.TEXT_COLOR);
+	protected void extractWidgetRenderState(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+		graphics.shadowedText(this.client.font, this.getTextFieldWidget().getTitle(), this.getX() + 2, this.getY() + 2, ColorUtil.TEXT_COLOR);
 
 		this.getTextFieldWidget().extractRenderState(graphics, mouseX, mouseY, delta);
 	}

--- a/src/main/java/dev/lambdaurora/spruceui/widget/text/SpruceNamedTextFieldWidget.java
+++ b/src/main/java/dev/lambdaurora/spruceui/widget/text/SpruceNamedTextFieldWidget.java
@@ -227,6 +227,6 @@ public class SpruceNamedTextFieldWidget extends AbstractSpruceWidget implements 
 	protected void renderWidget(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
 		graphics.drawShadowedText(this.client.font, this.getTextFieldWidget().getTitle(), this.getX() + 2, this.getY() + 2, ColorUtil.TEXT_COLOR);
 
-		this.getTextFieldWidget().render(graphics, mouseX, mouseY, delta);
+		this.getTextFieldWidget().extractRenderState(graphics, mouseX, mouseY, delta);
 	}
 }

--- a/src/main/java/dev/lambdaurora/spruceui/widget/text/SpruceTextAreaWidget.java
+++ b/src/main/java/dev/lambdaurora/spruceui/widget/text/SpruceTextAreaWidget.java
@@ -148,7 +148,7 @@ public class SpruceTextAreaWidget extends AbstractSpruceTextInputWidget<SpruceTe
 	@Override
 	protected void insertCharacter(String character) {
 		if (this.lines.isEmpty()) {
-			this.lines.add(String.valueOf(character));
+			this.lines.add(character);
 			this.setCursorToStart();
 			return;
 		} else {
@@ -431,8 +431,8 @@ public class SpruceTextAreaWidget extends AbstractSpruceTextInputWidget<SpruceTe
 	/* Rendering */
 
 	@Override
-	protected void renderWidget(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
-		super.renderWidget(graphics, mouseX, mouseY, delta);
+	protected void extractWidgetRenderState(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+		super.extractWidgetRenderState(graphics, mouseX, mouseY, delta);
 
 		this.drawText(graphics);
 		this.drawCursor(graphics);
@@ -452,7 +452,7 @@ public class SpruceTextAreaWidget extends AbstractSpruceTextInputWidget<SpruceTe
 		var placeholder = this.getPlaceholder();
 
 		if (this.getText().isEmpty() && placeholder != null) {
-			graphics.drawShadowedText(this.client.font, placeholder, textX, lineY, textColor);
+			graphics.shadowedText(this.client.font, placeholder, textX, lineY, textColor);
 			return;
 		}
 
@@ -462,7 +462,7 @@ public class SpruceTextAreaWidget extends AbstractSpruceTextInputWidget<SpruceTe
 				continue;
 			if (line.endsWith("\n")) line = line.substring(0, line.length() - 1);
 
-			graphics.drawShadowedText(this.font, Component.literal(line), textX, lineY, textColor);
+			graphics.shadowedText(this.font, Component.literal(line), textX, lineY, textColor);
 			this.drawSelection(graphics, line, lineY, row);
 
 			lineY += this.font.lineHeight;
@@ -515,7 +515,7 @@ public class SpruceTextAreaWidget extends AbstractSpruceTextInputWidget<SpruceTe
 		if (!this.isFocused())
 			return;
 		if (this.lines.isEmpty()) {
-			graphics.drawShadowedText(this.font, Component.literal("_"), this.getX(), this.getY() + 4, ColorUtil.TEXT_COLOR);
+			graphics.shadowedText(this.font, Component.literal("_"), this.getX(), this.getY() + 4, ColorUtil.TEXT_COLOR);
 			return;
 		}
 
@@ -529,7 +529,7 @@ public class SpruceTextAreaWidget extends AbstractSpruceTextInputWidget<SpruceTe
 		if (this.cursor.row < this.lines.size() - 1 || this.cursor.column < cursorLine.length() || this.doesLineOccupyFullSpace(cursorLine))
 			graphics.fill(cursorX - 1, cursorY - 1, cursorX, cursorY + 9, ColorUtil.TEXT_COLOR);
 		else
-			graphics.drawShadowedText(this.font, "_", cursorX, cursorY, ColorUtil.TEXT_COLOR);
+			graphics.shadowedText(this.font, "_", cursorX, cursorY, ColorUtil.TEXT_COLOR);
 	}
 
 	/**

--- a/src/main/java/dev/lambdaurora/spruceui/widget/text/SpruceTextFieldWidget.java
+++ b/src/main/java/dev/lambdaurora/spruceui/widget/text/SpruceTextFieldWidget.java
@@ -419,8 +419,8 @@ public class SpruceTextFieldWidget extends AbstractSpruceTextInputWidget<SpruceT
 	/* Rendering */
 
 	@Override
-	protected void renderWidget(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
-		super.renderWidget(graphics, mouseX, mouseY, delta);
+	protected void extractWidgetRenderState(SpruceGuiGraphics graphics, int mouseX, int mouseY, float delta) {
+		super.extractWidgetRenderState(graphics, mouseX, mouseY, delta);
 
 		this.drawText(graphics);
 		this.drawCursor(graphics);
@@ -445,7 +445,7 @@ public class SpruceTextFieldWidget extends AbstractSpruceTextInputWidget<SpruceT
 		var placeholder = this.getPlaceholder();
 
 		if (this.text.isEmpty() && placeholder != null) {
-			graphics.drawShadowedText(this.client.font, placeholder, x, y, textColor);
+			graphics.shadowedText(this.client.font, placeholder, x, y, textColor);
 			return;
 		}
 
@@ -454,7 +454,7 @@ public class SpruceTextFieldWidget extends AbstractSpruceTextInputWidget<SpruceT
 				this.getInnerWidth()
 		);
 
-		graphics.drawShadowedText(
+		graphics.shadowedText(
 				this.client.font, this.renderTextProvider.apply(displayedText, this.firstCharacterIndex),
 				x, y, textColor
 		);
@@ -499,7 +499,7 @@ public class SpruceTextFieldWidget extends AbstractSpruceTextInputWidget<SpruceT
 		int cursorY = this.getY() + this.getHeight() / 2 - 4;
 
 		if (this.text.isEmpty()) {
-			graphics.drawShadowedText(this.client.font, Component.literal("_"),
+			graphics.shadowedText(this.client.font, Component.literal("_"),
 					this.getX() + 4, cursorY, ColorUtil.TEXT_COLOR);
 			return;
 		}
@@ -514,7 +514,7 @@ public class SpruceTextFieldWidget extends AbstractSpruceTextInputWidget<SpruceT
 		if (this.cursor.column - this.firstCharacterIndex < cursorLine.length())
 			graphics.fill(cursorX - 1, cursorY - 1, cursorX, cursorY + 9, ColorUtil.TEXT_COLOR);
 		else
-			graphics.drawShadowedText(this.client.font, "_", cursorX, cursorY, ColorUtil.TEXT_COLOR);
+			graphics.shadowedText(this.client.font, "_", cursorX, cursorY, ColorUtil.TEXT_COLOR);
 	}
 
 	/* Narration */

--- a/src/main/java/dev/lambdaurora/spruceui/wrapper/VanillaButtonWrapper.java
+++ b/src/main/java/dev/lambdaurora/spruceui/wrapper/VanillaButtonWrapper.java
@@ -14,7 +14,7 @@ import dev.lambdaurora.spruceui.widget.AbstractSpruceButtonWidget;
 import dev.lambdaurora.spruceui.widget.SpruceElement;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.client.input.KeyEvent;
@@ -39,9 +39,9 @@ public class VanillaButtonWrapper extends AbstractWidget implements SpruceElemen
 	}
 
 	@Override
-	public void renderWidget(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+	public void extractWidgetRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
 		this.widget.getPosition().setRelativeY(this.getY());
-		this.widget.render(graphics, mouseX, mouseY, delta);
+		this.widget.extractRenderState(graphics, mouseX, mouseY, delta);
 	}
 
 	@Override

--- a/src/main/resources/spruceui.accesswidener
+++ b/src/main/resources/spruceui.accesswidener
@@ -1,1 +1,0 @@
-accessWidener v2 official

--- a/src/main/resources/spruceui.accesswidener
+++ b/src/main/resources/spruceui.accesswidener
@@ -1,3 +1,1 @@
 accessWidener v2 official
-
-accessible class net/minecraft/client/gui/GuiGraphics$ScissorStack

--- a/src/main/resources/spruceui.mixins.json
+++ b/src/main/resources/spruceui.mixins.json
@@ -4,7 +4,7 @@
 	"compatibilityLevel": "JAVA_25",
 	"client": [
 		"GameRendererMixin",
-		"GuiGraphicsMixin",
+      "GuiGraphicsExtractorMixin",
 		"MinecraftClientMixin",
 		"ScreenMixin"
 	],

--- a/src/testmod/java/dev/lambdaurora/spruceui/test/SpruceUITest.java
+++ b/src/testmod/java/dev/lambdaurora/spruceui/test/SpruceUITest.java
@@ -236,11 +236,11 @@ public final class SpruceUITest {
 					(screen, graphics, mouseX, mouseY, tickDelta) -> {
 						var text = "Greetings from SpruceUI";
 						int width = screen.getFont().width(text);
-						graphics.drawShadowedText(screen.getFont(), text, screen.width - width - 2, 2, 0xffffffff);
+						graphics.shadowedText(screen.getFont(), text, screen.width - width - 2, 2, 0xffffffff);
 
 						var tickText = String.valueOf(tick[0]);
 						int tickWidth = screen.getFont().width(tickText);
-						graphics.drawShadowedText(
+						graphics.shadowedText(
 								screen.getFont(), tickText,
 								screen.width - tickWidth - 2, 4 + screen.getFont().lineHeight,
 								0xffffffff

--- a/src/testmod/java/dev/lambdaurora/spruceui/test/gui/tooltip/CheckboxTooltipComponent.java
+++ b/src/testmod/java/dev/lambdaurora/spruceui/test/gui/tooltip/CheckboxTooltipComponent.java
@@ -31,7 +31,7 @@ public class CheckboxTooltipComponent implements SpruceClientTooltipComponent {
 
 	@Override
 	public void extractImage(@NotNull Font font, int x, int y, int width, int height, @NotNull SpruceGuiGraphics graphics) {
-		graphics.drawSprite(
+		graphics.blitSprite(
 				RenderPipelines.GUI_TEXTURED, SpruceCheckboxWidget.BACKGROUND_TEXTURE.get(true, false),
 				x + 4, y + 4, 20, 20
 		);
@@ -39,7 +39,7 @@ public class CheckboxTooltipComponent implements SpruceClientTooltipComponent {
 		long currentTime = System.currentTimeMillis() % ANIMATION_DURATION;
 
 		if (currentTime > ANIMATION_DURATION / 2) {
-			graphics.drawSprite(
+			graphics.blitSprite(
 					RenderPipelines.GUI_TEXTURED, SpruceCheckboxWidget.CHECKED_TEXTURE,
 					x + 4, y + 4, 20, 20,
 					0xff00ff00

--- a/src/testmod/java/dev/lambdaurora/spruceui/test/gui/tooltip/CheckboxTooltipComponent.java
+++ b/src/testmod/java/dev/lambdaurora/spruceui/test/gui/tooltip/CheckboxTooltipComponent.java
@@ -30,7 +30,7 @@ public class CheckboxTooltipComponent implements SpruceClientTooltipComponent {
 	}
 
 	@Override
-	public void renderImage(@NotNull Font font, int x, int y, int width, int height, @NotNull SpruceGuiGraphics graphics) {
+	public void extractImage(@NotNull Font font, int x, int y, int width, int height, @NotNull SpruceGuiGraphics graphics) {
 		graphics.drawSprite(
 				RenderPipelines.GUI_TEXTURED, SpruceCheckboxWidget.BACKGROUND_TEXTURE.get(true, false),
 				x + 4, y + 4, 20, 20


### PR DESCRIPTION
This also has a side-commit of fixing the Neoforged Maven URI.

Various acknowledgements of subpars:
- `render*` methods that overrode Vanilla have been renamed to `extract*RenderState`
  - This did not cover the whole API surface, as we'd like further input whether all remaining `render*` functions should follow the same convention of `extract*RenderState` or `extractGui` in the case of rendering a screen.
- The NeoForge GUI render event hook has currently been commented out as it's unknown whether NeoForge will retain the same API name or use a new one. Given the hook is still named from MCP, it's quite likely it'll still be the same and the comment can be merely removed. But as there's no production NeoForge yet, it cannot be tested.
- GuiGraphicsAccessor has not been renamed yet.
- There are other renames in Vanilla code that has not been yet reflected in SpruceUI. Should those also be renamed to match the Vanilla counterpart?
- Yumi has been left on snapshot 6; have yet run into a code path that causes a crash, but it doesn't mean it does not contain a codepath that hasn't been tested that crashes.